### PR TITLE
Add PathBuf support for environment variables

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -2,7 +2,7 @@ use crate::error::EnvarError;
 use crate::list_envar::ListEnvar;
 use crate::list_envar::ListEnvarConfig;
 use crate::ErrorReason;
-use std::borrow::Cow;
+use std::{borrow::Cow, path::PathBuf};
 
 enum EnvarStore<T> {
     OnStartup(std::sync::OnceLock<T>),
@@ -194,6 +194,12 @@ impl EnvarParse<bool> for EnvarParser<bool> {
             }),
         });
     }
+}
+
+impl EnvarParse<PathBuf> for EnvarParser<PathBuf> {
+  fn parse(_varname: Cow<'static, str>, value: &str) -> Result<PathBuf, EnvarError> {
+        Ok(PathBuf::from(value))
+  }
 }
 
 impl<T, C> EnvarParse<ListEnvar<T, C>> for EnvarParser<ListEnvar<T, C>>

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::{Envar, EnvarDef, EnvarError, ListEnvar, ListEnvarConfig};
-use std::sync::Mutex;
+use std::{path::PathBuf, sync::Mutex};
 
 static SINGLE_THREAD_ASSURANCE: Mutex<()> = Mutex::new(());
 
@@ -140,6 +140,16 @@ fn test_string_type() {
     // Test with whitespace
     set_env_var("TEST_STRING", "  spaces around  ");
     assert_eq!(VAR_STRING.value().unwrap(), "  spaces around  ");
+}
+
+#[test]
+fn test_pathbuf_type() {
+  let _lock = get_test_lock();
+
+  clear_env_var("TEST_STRING");
+  static VAR_STRING: Envar<PathBuf> = Envar::on_demand("TEST_STRING", || EnvarDef::Unset);
+  set_env_var("TEST_STRING", "/some/path");
+  assert_eq!(VAR_STRING.value().unwrap(), PathBuf::from("/some/path"));
 }
 
 #[test]


### PR DESCRIPTION
Implements EnvarParse<PathBuf> to allow parsing environment variable values directly into PathBuf types, with corresponding test coverage.

The changes add:

- EnvarParse<PathBuf> implementation in src/core.rs:199
- Test coverage in src/tests.rs:146 that verifies PathBuf parsing works correctly

resolves #1